### PR TITLE
fix jit bitcode compilation on x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 
 REGRESS = equality strstr
 
+COMPILE.cxx.bc = $(CLANG) -xc++ $(BITCODE_CXXFLAGS) $(PG_CXXFLAGS) $(CPPFLAGS) -emit-llvm -c
+
 include $(PGXS)
 
 lintcheck:


### PR DESCRIPTION
bitcode building on x86 was having an issue, this fixes it.